### PR TITLE
feat: add support for multiple LLM providers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "requests>=2.31.0",
     "click>=8.0.0",
     "openai>=1.0.0",
+    "anthropic>=0.18.0",
 ]
 
 [project.scripts]

--- a/src/concierge_clients/providers/anthropic_provider.py
+++ b/src/concierge_clients/providers/anthropic_provider.py
@@ -1,0 +1,110 @@
+from typing import Any, Dict, List, Optional
+import json
+try:
+    from anthropic import Anthropic
+except ImportError:
+    Anthropic = None
+
+from .base import LLMProvider
+
+class AnthropicProvider(LLMProvider):
+    def __init__(self, api_key: str, model: str = "claude-3-opus-20240229"):
+        if Anthropic is None:
+            raise ImportError("anthropic package is required for AnthropicProvider")
+        self.client = Anthropic(api_key=api_key)
+        self.model = model
+
+    def chat(self, messages: List[Dict[str, Any]], tools: Optional[List[Dict[str, Any]]] = None) -> Any:
+        # Convert OpenAI-style messages to Anthropic format if necessary
+        # Anthropic expects 'user' and 'assistant' roles. 'system' message is a separate parameter.
+
+        system_prompt = None
+        anthropic_messages = []
+
+        for msg in messages:
+            if msg["role"] == "system":
+                system_prompt = msg["content"]
+            elif msg["role"] == "tool":
+                # Anthropic tool results
+                anthropic_messages.append({
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": msg["tool_call_id"],
+                            "content": msg["content"]
+                        }
+                    ]
+                })
+            elif "tool_calls" in msg and msg["tool_calls"]:
+                 # Assistant message with tool calls
+                content = []
+                if msg["content"]:
+                    content.append({"type": "text", "text": msg["content"]})
+
+                for tc in msg["tool_calls"]:
+                    content.append({
+                        "type": "tool_use",
+                        "id": tc["id"],
+                        "name": tc["function"]["name"],
+                        "input": json.loads(tc["function"]["arguments"])
+                    })
+                anthropic_messages.append({"role": "assistant", "content": content})
+            else:
+                anthropic_messages.append(msg)
+
+        kwargs = {
+            "model": self.model,
+            "messages": anthropic_messages,
+            "max_tokens": 4096,
+        }
+
+        if system_prompt:
+            kwargs["system"] = system_prompt
+
+        if tools:
+            kwargs["tools"] = tools
+
+        return self.client.messages.create(**kwargs)
+
+    def convert_tools(self, tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        anthropic_tools = []
+        for tool in tools:
+             # Check if it's already in OpenAI format (which we might receive) and convert to Anthropic
+            if "type" in tool and tool["type"] == "function":
+                 func = tool["function"]
+                 anthropic_tools.append({
+                    "name": func["name"],
+                    "description": func["description"],
+                    "input_schema": func["parameters"]
+                })
+            else:
+                # Assume Concierge format which is close to Anthropic's
+                anthropic_tools.append({
+                    "name": tool["name"],
+                    "description": tool["description"],
+                    "input_schema": tool["input_schema"]
+                })
+        return anthropic_tools
+
+    def parse_response(self, response: Any) -> Dict[str, Any]:
+        content = ""
+        tool_calls = []
+
+        for block in response.content:
+            if block.type == "text":
+                content += block.text
+            elif block.type == "tool_use":
+                tool_calls.append({
+                    "id": block.id,
+                    "type": "function",
+                    "function": {
+                        "name": block.name,
+                        "arguments": json.dumps(block.input)
+                    }
+                })
+
+        return {
+            "content": content,
+            "tool_calls": tool_calls
+        }

--- a/src/concierge_clients/providers/base.py
+++ b/src/concierge_clients/providers/base.py
@@ -1,0 +1,47 @@
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional
+
+class LLMProvider(ABC):
+    """Abstract base class for LLM providers."""
+
+    @abstractmethod
+    def chat(self, messages: List[Dict[str, Any]], tools: Optional[List[Dict[str, Any]]] = None) -> Any:
+        """
+        Send a chat request to the provider.
+
+        Args:
+            messages: List of message dictionaries (role, content).
+            tools: Optional list of tools in the provider's format (or generic format to be converted).
+
+        Returns:
+            The raw response object from the provider.
+        """
+        pass
+
+    @abstractmethod
+    def convert_tools(self, tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """
+        Convert generic tools to the provider-specific format.
+
+        Args:
+            tools: List of generic tool definitions.
+
+        Returns:
+            List of tools in the provider's format.
+        """
+        pass
+
+    @abstractmethod
+    def parse_response(self, response: Any) -> Dict[str, Any]:
+        """
+        Parse the provider's response into a standard format.
+
+        Args:
+            response: The raw response from the provider.
+
+        Returns:
+            A dictionary containing:
+            - content: The text content of the response.
+            - tool_calls: A list of tool calls (if any).
+        """
+        pass

--- a/src/concierge_clients/providers/factory.py
+++ b/src/concierge_clients/providers/factory.py
@@ -1,0 +1,25 @@
+from typing import Optional
+from .base import LLMProvider
+from .openai_provider import OpenAIProvider
+from .anthropic_provider import AnthropicProvider
+
+def get_provider(provider_name: str, **kwargs) -> LLMProvider:
+    """
+    Factory function to get an LLM provider instance.
+
+    Args:
+        provider_name: The name of the provider ("openai" or "anthropic").
+        **kwargs: Arguments to pass to the provider constructor.
+
+    Returns:
+        An instance of LLMProvider.
+
+    Raises:
+        ValueError: If the provider name is not supported.
+    """
+    if provider_name.lower() == "openai":
+        return OpenAIProvider(**kwargs)
+    elif provider_name.lower() == "anthropic":
+        return AnthropicProvider(**kwargs)
+    else:
+        raise ValueError(f"Unsupported provider: {provider_name}")

--- a/src/concierge_clients/providers/openai_provider.py
+++ b/src/concierge_clients/providers/openai_provider.py
@@ -1,0 +1,64 @@
+from typing import Any, Dict, List, Optional
+from openai import OpenAI
+from .base import LLMProvider
+
+class OpenAIProvider(LLMProvider):
+    def __init__(self, api_base: str, api_key: str, model: str = "gpt-5"):
+        self.client = OpenAI(base_url=api_base, api_key=api_key)
+        self.model = model
+
+    def chat(self, messages: List[Dict[str, Any]], tools: Optional[List[Dict[str, Any]]] = None) -> Any:
+        kwargs = {
+            "model": self.model,
+            "messages": messages,
+        }
+        if tools:
+            kwargs["tools"] = tools
+            kwargs["tool_choice"] = "auto"
+
+        return self.client.chat.completions.create(**kwargs)
+
+    def convert_tools(self, tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        # OpenAI expects tools in the format: {"type": "function", "function": {...}}
+        # Assuming input tools are already in or close to this format, or need wrapping.
+        # Based on client_tool_calling.py, it seems we might receive Concierge tools and need to convert them.
+        # Let's reuse the logic from client_tool_calling.py if possible, or reimplement it here.
+
+        openai_tools = []
+        for tool in tools:
+            # Check if it's already in OpenAI format
+            if "type" in tool and tool["type"] == "function":
+                openai_tools.append(tool)
+            else:
+                # Convert from Concierge format
+                openai_tools.append({
+                    "type": "function",
+                    "function": {
+                        "name": tool["name"],
+                        "description": tool["description"],
+                        "parameters": tool["input_schema"]
+                    }
+                })
+        return openai_tools
+
+    def parse_response(self, response: Any) -> Dict[str, Any]:
+        message = response.choices[0].message
+        result = {
+            "content": message.content,
+            "tool_calls": []
+        }
+
+        if message.tool_calls:
+            result["tool_calls"] = [
+                {
+                    "id": tc.id,
+                    "type": tc.type,
+                    "function": {
+                        "name": tc.function.name,
+                        "arguments": tc.function.arguments
+                    }
+                }
+                for tc in message.tool_calls
+            ]
+
+        return result

--- a/tests/test_provider_abstraction.py
+++ b/tests/test_provider_abstraction.py
@@ -1,0 +1,75 @@
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+import sys
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+# Mock openai and requests before importing modules that use them
+sys.modules["openai"] = MagicMock()
+sys.modules["requests"] = MagicMock()
+sys.modules["yaml"] = MagicMock()
+
+# Mock pydantic with a real class for BaseModel so issubclass works
+class MockBaseModel:
+    pass
+mock_pydantic = MagicMock()
+mock_pydantic.BaseModel = MockBaseModel
+sys.modules["pydantic"] = mock_pydantic
+sys.modules["pydantic_core"] = MagicMock()
+
+# Mock concierge package to avoid importing dependencies
+mock_concierge = MagicMock()
+mock_config = MagicMock()
+mock_config.SERVER_HOST = "localhost"
+mock_config.SERVER_PORT = 8080
+mock_concierge.config = mock_config
+sys.modules["concierge"] = mock_concierge
+sys.modules["concierge.config"] = mock_config
+
+from concierge_clients.providers.factory import get_provider
+from concierge_clients.providers.openai_provider import OpenAIProvider
+from concierge_clients.providers.anthropic_provider import AnthropicProvider
+from concierge_clients.client_tool_calling import ToolCallingClient
+
+def test_factory():
+    openai_provider = get_provider("openai", api_base="http://test", api_key="test")
+    assert isinstance(openai_provider, OpenAIProvider)
+
+    # Mock Anthropic import for test environment where it might not be installed
+    with patch("concierge_clients.providers.anthropic_provider.Anthropic") as mock_anthropic:
+        anthropic_provider = get_provider("anthropic", api_key="test")
+        assert isinstance(anthropic_provider, AnthropicProvider)
+
+def test_client_initialization():
+    # Test OpenAI initialization
+    client_openai = ToolCallingClient(api_base="http://test", api_key="test", provider_name="openai")
+    assert isinstance(client_openai.llm_provider, OpenAIProvider)
+
+    # Test Anthropic initialization
+    with patch("concierge_clients.providers.anthropic_provider.Anthropic") as mock_anthropic:
+        client_anthropic = ToolCallingClient(api_base="http://test", api_key="test", provider_name="anthropic")
+        assert isinstance(client_anthropic.llm_provider, AnthropicProvider)
+
+def test_openai_provider_conversion():
+    provider = OpenAIProvider(api_base="http://test", api_key="test")
+    tools = [{"name": "test_tool", "description": "test", "input_schema": {"type": "object"}}]
+    converted = provider.convert_tools(tools)
+    assert converted[0]["type"] == "function"
+    assert converted[0]["function"]["name"] == "test_tool"
+
+def test_anthropic_provider_conversion():
+    with patch("concierge_clients.providers.anthropic_provider.Anthropic") as mock_anthropic:
+        provider = AnthropicProvider(api_key="test")
+        tools = [{"name": "test_tool", "description": "test", "input_schema": {"type": "object"}}]
+        converted = provider.convert_tools(tools)
+        assert converted[0]["name"] == "test_tool"
+        assert "input_schema" in converted[0]
+
+if __name__ == "__main__":
+    test_factory()
+    test_client_initialization()
+    test_openai_provider_conversion()
+    test_anthropic_provider_conversion()
+    print("All tests passed!")


### PR DESCRIPTION
## Summary
This PR adds support for multiple LLM providers (OpenAI and Anthropic) by introducing a provider abstraction layer.

## Changes
- Add abstract  base class
- Implement  and 
- Refactor  to use provider abstraction
- Add provider factory for instantiation
- Add  dependency to 
- Add unit tests for provider abstraction

## Usage
```bash
# Use OpenAI (default)
python src/concierge_clients/client_tool_calling.py <api_base> <api_key>

# Use Anthropic
python src/concierge_clients/client_tool_calling.py <api_base> <api_key> --provider anthropic --model claude-3-opus-20240229
```

Related:
- #7