### PR TITLE
(#73) v0.12 Add support for moderation for trusted and virtual (untrusted) servers

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -22,6 +22,7 @@ from concierge.adapters.raw_server_adapter import RawServerAdapter
 from concierge.state import get_default_backend
 from concierge.state.base import StateBackend
 from concierge.backends.code_backend import CodeBackend
+from concierge.security.moderation import ContentModerator, ModerationConfig
 from mcp.server.lowlevel.server import request_ctx
 
 
@@ -87,6 +88,7 @@ class Concierge:
         state_backend: Optional[StateBackend] = None,
         workflow_instructions: Optional[str] = None,
         upstream_servers: Optional[List[str]] = None,
+        content_moderation: Optional[ModerationConfig] = None,
         **fastmcp_kwargs,
     ):
         if isinstance(server, FastMCP):
@@ -126,6 +128,12 @@ class Concierge:
         self._state = state_backend or get_default_backend()
 
         self._upstream_servers = upstream_servers or []
+
+        # Content moderation for upstream tool I/O
+        if content_moderation and content_moderation.enabled:
+            self._moderator = ContentModerator(content_moderation)
+        else:
+            self._moderator = None
 
         self._stages: Dict[str, List[str]] = {}  # stage_name -> [tool_names]
         self._transitions: Dict[str, List[str]] = {}  # stage_name -> [next_stages]

--- a/proxy.py
+++ b/proxy.py
@@ -252,6 +252,14 @@ class SessionPool:
             await self.cleanup_session(session_id)
 
 
+def _extract_result_text(result: CallToolResult) -> str:
+    parts = []
+    for content in result.content or []:
+        if hasattr(content, "text"):
+            parts.append(content.text)
+    return "\n".join(parts)
+
+
 def install_proxy_handlers(concierge_instance) -> None:
     """Install protocol-level handlers that forward to upstream servers."""
     upstream_urls = concierge_instance._upstream_servers
@@ -307,6 +315,26 @@ def install_proxy_handlers(concierge_instance) -> None:
 
     original_call_tool = handlers.get(types.CallToolRequest)
 
+    moderator = concierge_instance._moderator
+
+    async def _moderate(content, tool_name: str) -> Optional[types.ServerResult]:
+        if not moderator:
+            return None
+        text = moderator.serialize(content) if not isinstance(content, str) else content
+        allowed, reason = await moderator.check(text)
+        if allowed:
+            return None
+        return types.ServerResult(
+            CallToolResult(
+                content=[
+                    types.TextContent(
+                        type="text", text=f"[BLOCKED] '{tool_name}': {reason}"
+                    )
+                ],
+                isError=True,
+            )
+        )
+
     async def _handle_call_tool(req: types.CallToolRequest) -> types.ServerResult:
         name = req.params.name
         arguments = req.params.arguments or {}
@@ -314,9 +342,15 @@ def install_proxy_handlers(concierge_instance) -> None:
         state = await _get_state()
         conn = state.tool_to_conn.get(name)
         if conn:
+            blocked = await _moderate(arguments, name)
+            if blocked:
+                return blocked
+
             upstream_name = state.tool_to_upstream_name.get(name, name)
             result = await conn.call_tool(upstream_name, arguments)
-            return types.ServerResult(result)
+
+            blocked = await _moderate(_extract_result_text(result), name)
+            return blocked if blocked else types.ServerResult(result)
 
         if original_call_tool:
             return await original_call_tool(req)

--- a/security/__init__.py
+++ b/security/__init__.py
@@ -1,0 +1,3 @@
+from concierge.security.moderation import ContentModerator, ModerationConfig
+
+__all__ = ["ContentModerator", "ModerationConfig"]

--- a/security/moderation.py
+++ b/security/moderation.py
@@ -1,0 +1,90 @@
+"""Content moderation for MCP tool inputs and outputs.
+
+Intercepts tool calls (both arguments and results) and runs configurable
+checks to block prompt injection, context poisoning, and data exfiltration
+from upstream servers.
+
+Provides basic deterministic checks (size limits, regex pattern matching)
+with hooks for remote validation and pluggable scanners.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+logger = logging.getLogger("concierge.security")
+
+DEFAULT_BLOCK_PATTERNS = [
+    r"IGNORE\s+(ALL\s+)?PREVIOUS\s+INSTRUCTIONS",
+    r"\[INST\]",
+    r"\[/INST\]",
+    r"\[SYSTEM\]",
+    r"<\|im_start\|>",
+    r"<\|im_end\|>",
+    r"BEGIN\s+SYSTEM\s+PROMPT",
+    r"END\s+SYSTEM\s+PROMPT",
+]
+
+
+@dataclass
+class ModerationConfig:
+    enabled: bool = True
+    max_size: int = 50_000
+    block_patterns: List[str] = field(
+        default_factory=lambda: list(DEFAULT_BLOCK_PATTERNS)
+    )
+
+    # Plumbing for future remote moderation endpoint
+    remote_endpoint: Optional[str] = None
+    remote_api_key: Optional[str] = None
+    remote_timeout: float = 5.0
+
+    # TODO: pluggable scanner interface (e.g. LLM Guard, Vigil)
+
+
+class ContentModerator:
+    """Checks text content for malicious patterns.
+
+    Called by the proxy to filter both tool inputs and outputs.
+    Returns (allowed, reason). The proxy decides what to do with it.
+    """
+
+    def __init__(self, config: ModerationConfig):
+        self._config = config
+        self._compiled_patterns = [
+            re.compile(p, re.IGNORECASE) for p in config.block_patterns
+        ]
+
+    async def check(self, text: str) -> tuple[bool, Optional[str]]:
+        """Check text content. Returns (allowed, reason)."""
+        if len(text) > self._config.max_size:
+            return (
+                False,
+                f"Content size ({len(text)}) exceeds limit ({self._config.max_size})",
+            )
+
+        for pattern in self._compiled_patterns:
+            match = pattern.search(text)
+            if match:
+                return False, f"Blocked pattern detected: '{match.group()}'"
+
+        # TODO: add more comprehensive moderation policies
+        # - PII detection / redaction
+        # - detect encoded payloads (base64 blobs, data URIs)
+        # - detect suspicious URLs / external endpoints
+        # - detect leaked credentials or API key patterns
+        # - pluggable scanner integration (LLM Guard, Vigil, etc.)
+        # - remote endpoint validation
+
+        return True, None
+
+    def serialize(self, obj: Any) -> str:
+        """Convert arguments dict to string for scanning."""
+        try:
+            return json.dumps(obj, default=str)
+        except (TypeError, ValueError):
+            return str(obj)


### PR DESCRIPTION
  - Initial change for security enhancements tracked under #73.
 - This change adds config driven moderation checks that intercept the input and output of upstream tool calls in proxy layer
 - This blocks oversized payloads and prompt injection before they reach the LLM context window
 - Also adds basic plumbing, future work will include LLM as a judge, rate limiting and RBAC

  Co-Authored-By: kathiru-dev <kathiru11@gmail.com>